### PR TITLE
Make the Yuki API host configurable by region (fixes Belgian administrations)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,12 @@ YUKI_API_KEY=
 # The administration/domain ID to use by default (GUID from get_administrations)
 YUKI_DOMAIN_ID=
 
+# Yuki API region: nl (default) or be. Belgian administrations must set be,
+# otherwise every data call fails with "Domain has no active database".
+YUKI_REGION=nl
+
+# Optional: full API base URL. Overrides YUKI_REGION when set.
+# YUKI_BASE_URL=https://api.yukiworks.be/ws/
+
 # Anthropic API key — only required for the test-agent script (npm run agent)
 ANTHROPIC_API_KEY=

--- a/README.md
+++ b/README.md
@@ -22,12 +22,15 @@ Then add it to your MCP host configuration (e.g. `claude_desktop_config.json`):
       "args": ["node_modules/@codemill-solutions/yuki-mcp/dist/index.js"],
       "env": {
         "YUKI_API_KEY": "your-api-key-here",
-        "YUKI_DOMAIN_ID": "your-administration-guid-here"
+        "YUKI_DOMAIN_ID": "your-administration-guid-here",
+        "YUKI_REGION": "nl"
       }
     }
   }
 }
 ```
+
+> **Belgian administrations must set `YUKI_REGION=be`.** See [API region](#api-region).
 
 ---
 
@@ -58,6 +61,7 @@ Edit `.env`:
 ```env
 YUKI_API_KEY=your-api-key-here
 YUKI_DOMAIN_ID=your-administration-guid-here  # optional at startup
+YUKI_REGION=nl                                # nl (default) or be
 ```
 
 `YUKI_DOMAIN_ID` can be left empty — the server starts without it. Call `get_administrations` to discover the correct GUID, then pass it via the `administrationId` parameter on individual tools.
@@ -86,6 +90,38 @@ Add to your MCP host configuration (e.g. `claude_desktop_config.json`):
   }
 }
 ```
+
+---
+
+## API region
+
+Yuki runs a separate API host per region, and an administration only exists on the host
+for its own region. A key for a Belgian administration authenticates successfully against
+the Dutch host but then fails on **every** data call with:
+
+```
+SOAP Fault: Domain has no active database
+```
+
+Set the region to match your administration:
+
+| Variable | Values | Default | Purpose |
+| --- | --- | --- | --- |
+| `YUKI_REGION` | `nl`, `be` | `nl` | Selects a known regional API host |
+| `YUKI_BASE_URL` | full URL | — | Overrides `YUKI_REGION` entirely; use for hosts not listed above |
+
+```env
+YUKI_REGION=be
+```
+
+`YUKI_BASE_URL` takes precedence when both are set, so a new or private host can be reached
+without waiting on a release:
+
+```env
+YUKI_BASE_URL=https://api.yukiworks.be/ws/
+```
+
+Defaults are unchanged — omitting both keeps the previous `api.yukiworks.nl` behaviour.
 
 ---
 

--- a/src/yuki-client.ts
+++ b/src/yuki-client.ts
@@ -4,8 +4,56 @@ import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 
-// Confirmed via WSDL inspection of api.yukiworks.nl
-const YUKI_BASE_URL = 'https://api.yukiworks.nl/ws/';
+// Yuki runs region-specific API hosts. An administration only exists on the
+// host for its own region, so calls to the wrong region authenticate fine but
+// then fail on every data call with "Domain has no active database".
+const YUKI_REGION_HOSTS: Record<string, string> = {
+  nl: 'https://api.yukiworks.nl/ws/',
+  be: 'https://api.yukiworks.be/ws/',
+};
+const DEFAULT_YUKI_REGION = 'nl';
+
+/**
+ * Append a hint when a fault looks like the caller is talking to the wrong
+ * regional host. Yuki returns the same opaque message for a genuinely
+ * unscoped API key and for a valid key pointed at the wrong region, which is
+ * otherwise very hard to diagnose.
+ */
+function regionHint(fault: string | null, url: string): string {
+  if (!fault || !/no active database/i.test(fault)) return '';
+  const alternatives = Object.entries(YUKI_REGION_HOSTS)
+    .filter(([, host]) => !url.startsWith(host))
+    .map(([region]) => region);
+  if (alternatives.length === 0) return '';
+  return (
+    ` (called ${url}. If this administration is not Dutch, set YUKI_REGION` +
+    ` to one of: ${alternatives.join(', ')} — or set YUKI_BASE_URL explicitly.)`
+  );
+}
+
+/**
+ * Resolve the Yuki API base URL.
+ *
+ * `YUKI_BASE_URL` (a full URL) takes precedence, so unlisted or future hosts
+ * can be reached without a code change. Otherwise `YUKI_REGION` selects a
+ * known regional host. Defaults to the Dutch host for backwards compatibility.
+ */
+export function resolveBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+  const explicit = env['YUKI_BASE_URL']?.trim();
+  if (explicit) return explicit.endsWith('/') ? explicit : `${explicit}/`;
+
+  const region = (env['YUKI_REGION']?.trim() || DEFAULT_YUKI_REGION).toLowerCase();
+  const host = YUKI_REGION_HOSTS[region];
+  if (!host) {
+    throw new Error(
+      `Unknown YUKI_REGION "${region}". Supported regions: ${Object.keys(YUKI_REGION_HOSTS).join(', ')}. ` +
+        'Alternatively set YUKI_BASE_URL to a full API URL.',
+    );
+  }
+  return host;
+}
+
+const YUKI_BASE_URL = resolveBaseUrl();
 const YUKI_NAMESPACE = 'http://www.theyukicompany.com/';
 
 // Tags that should always be treated as arrays even when there is only one element
@@ -338,7 +386,7 @@ export class YukiClient {
       if (axios.isAxiosError(err)) {
         if (err.response?.data) {
           const fault = this.extractSoapFault(err.response.data as string);
-          if (fault) throw new Error(`SOAP Fault: ${fault}`);
+          if (fault) throw new Error(`SOAP Fault: ${fault}${regionHint(fault, url)}`);
           throw new Error(`HTTP ${err.response.status} ${err.response.statusText} from ${url}`);
         }
         throw new Error(`Network error calling Yuki API: ${err.message}`);
@@ -355,7 +403,7 @@ export class YukiClient {
 
     if (body['Fault']) {
       const fault = this.extractSoapFault(responseData);
-      throw new Error(`SOAP Fault: ${fault ?? 'Unknown SOAP fault'}`);
+      throw new Error(`SOAP Fault: ${fault ?? 'Unknown SOAP fault'}${regionHint(fault, url)}`);
     }
 
     // Unwrap <{method}Response><{method}Result> automatically


### PR DESCRIPTION
## Problem

`YUKI_BASE_URL` is hardcoded to `api.yukiworks.nl`:

https://github.com/CodeMill-Solutions/yuki-mcp/blob/main/src/yuki-client.ts#L8

Yuki serves each region from its own API host, and an administration only exists on the host for its own region. For a Belgian administration the server is therefore unusable — and it fails in a confusing way, because `Authenticate` **succeeds** against the Dutch host and returns a valid session ID. Only the subsequent data calls fail:

```
SOAP Fault: Domain has no active database
```

`get_administrations` also works, which makes it look like the connection is healthy. Every actual data tool then fails with that same message.

The message is doubly misleading because the README already documents it as an API-key scoping problem. It turns out the exact same fault is returned for a valid key pointed at the wrong regional host, so there is no way to tell the two apart from the output. There is currently no env var or option to change the host, so the only workaround is patching `dist/` after every install.

## Change

Two new environment variables, both optional and both defaulting to today's behaviour:

| Variable | Values | Default | Purpose |
| --- | --- | --- | --- |
| `YUKI_REGION` | `nl`, `be` | `nl` | Selects a known regional API host |
| `YUKI_BASE_URL` | full URL | — | Overrides `YUKI_REGION`; escape hatch for hosts not listed |

I went with a region enum as the primary knob since it is the discoverable, hard-to-typo option, plus a full-URL override so nobody is blocked on a release if Yuki adds a host.

I deliberately did **not** add automatic `.nl` → `.be` fallback. It would double the latency of every genuinely failing call, and since the same fault also means "API key not scoped to this administration", a silent retry would mask a real misconfiguration rather than surface it. Instead the fault message now names the host it called and the regions it could try:

```
SOAP Fault: Domain has no active database (called https://api.yukiworks.nl/ws/Accounting.asmx.
If this administration is not Dutch, set YUKI_REGION to one of: be — or set YUKI_BASE_URL explicitly.)
```

## Compatibility

Fully backwards compatible. With neither variable set the resolved host is `https://api.yukiworks.nl/ws/`, exactly as before. No tool signatures change.

## Testing

`resolveBaseUrl` is exported and takes an injectable env, so it is unit-testable. I verified:

| Case | Result |
| --- | --- |
| no vars set | `https://api.yukiworks.nl/ws/` (unchanged) |
| `YUKI_REGION=nl` / `be` | correct host |
| `YUKI_REGION=BE`, `" be "` | normalised (case + whitespace) |
| `YUKI_REGION=` (empty) | falls back to default |
| `YUKI_BASE_URL` + `YUKI_REGION` both set | base URL wins |
| `YUKI_BASE_URL` without trailing slash | slash appended |
| `YUKI_REGION=fr` | throws, listing supported regions |

End-to-end against a real Belgian administration: default config reproduces the fault (now with the region hint), `YUKI_REGION=be` returns GL data successfully. `npm run build` passes clean.

I have not added a test file, as the repo does not currently have a test setup — happy to add one if you'd like to point me at a preferred framework.

## Docs

README gains an **API region** section, and `.env.example` / the quick-start config block mention `YUKI_REGION`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)